### PR TITLE
fix: isolate preprocessor obj/bin per consumer to avoid parallel-restore race

### DIFF
--- a/src/Aviationexam.PayPalSdk.Orders/Aviationexam.PayPalSdk.Orders.csproj
+++ b/src/Aviationexam.PayPalSdk.Orders/Aviationexam.PayPalSdk.Orders.csproj
@@ -103,9 +103,12 @@
 
     <PropertyGroup>
       <PreprocessOpenApiProject>$(MSBuildThisFileDirectory)..\Aviationexam.PreprocessOpenApi\Aviationexam.PreprocessOpenApi.csproj</PreprocessOpenApiProject>
+      <!-- Isolated obj/bin per caller to prevent parallel-restore race on the shared preprocessor project (MSB3491). -->
+      <PreprocessOpenApiObjDir>$(MSBuildProjectDirectory)/obj/PreprocessOpenApi/</PreprocessOpenApiObjDir>
+      <PreprocessOpenApiBinDir>$(MSBuildProjectDirectory)/obj/PreprocessOpenApi/bin/</PreprocessOpenApiBinDir>
     </PropertyGroup>
 
-    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet run --project &quot;$(PreprocessOpenApiProject)&quot; --configuration Release -- &quot;$(PayPalOriginalOpenApiV2SpecificationFile)&quot; &quot;$(PayPalOpenApiV2SpecificationFile)&quot;" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet run --project &quot;$(PreprocessOpenApiProject)&quot; --configuration Release -p:BaseIntermediateOutputPath=&quot;$(PreprocessOpenApiObjDir)&quot; -p:BaseOutputPath=&quot;$(PreprocessOpenApiBinDir)&quot; -- &quot;$(PayPalOriginalOpenApiV2SpecificationFile)&quot; &quot;$(PayPalOpenApiV2SpecificationFile)&quot;" />
   </Target>
 
   <Target

--- a/src/Aviationexam.PayPalSdk.Payments/Aviationexam.PayPalSdk.Payments.csproj
+++ b/src/Aviationexam.PayPalSdk.Payments/Aviationexam.PayPalSdk.Payments.csproj
@@ -103,9 +103,12 @@
 
     <PropertyGroup>
       <PreprocessOpenApiProject>$(MSBuildThisFileDirectory)..\Aviationexam.PreprocessOpenApi\Aviationexam.PreprocessOpenApi.csproj</PreprocessOpenApiProject>
+      <!-- Isolated obj/bin per caller to prevent parallel-restore race on the shared preprocessor project (MSB3491). -->
+      <PreprocessOpenApiObjDir>$(MSBuildProjectDirectory)/obj/PreprocessOpenApi/</PreprocessOpenApiObjDir>
+      <PreprocessOpenApiBinDir>$(MSBuildProjectDirectory)/obj/PreprocessOpenApi/bin/</PreprocessOpenApiBinDir>
     </PropertyGroup>
 
-    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet run --project &quot;$(PreprocessOpenApiProject)&quot; --configuration Release -- &quot;$(PayPalOriginalOpenApiV2SpecificationFile)&quot; &quot;$(PayPalOpenApiV2SpecificationFile)&quot;" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet run --project &quot;$(PreprocessOpenApiProject)&quot; --configuration Release -p:BaseIntermediateOutputPath=&quot;$(PreprocessOpenApiObjDir)&quot; -p:BaseOutputPath=&quot;$(PreprocessOpenApiBinDir)&quot; -- &quot;$(PayPalOriginalOpenApiV2SpecificationFile)&quot; &quot;$(PayPalOpenApiV2SpecificationFile)&quot;" />
   </Target>
 
   <Target


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure during `dotnet restore`:

```
error MSB3491: Could not write lines to file
"obj/Release/net10.0/Aviationexam.PreprocessOpenApi.AssemblyInfoInputs.cache".
The file already exists.
```

## Root cause

Both `Aviationexam.PayPalSdk.Orders` and `Aviationexam.PayPalSdk.Payments` declare a target hooked to `BeforeTargets="Restore"` that runs:

```
dotnet run --project ../Aviationexam.PreprocessOpenApi/Aviationexam.PreprocessOpenApi.csproj --configuration Release -- ...
```

Because `dotnet restore` on the `slnx` restores projects **in parallel**, both invocations fire at the same time. `dotnet run` implicitly builds the project, so both consumers concurrently build the shared `Aviationexam.PreprocessOpenApi` project into the same `obj/Release/net10.0/` directory and race on `Aviationexam.PreprocessOpenApi.AssemblyInfoInputs.cache`.

The log confirms it - two `Preprocess openapi.v2.original.json to the openapi.v2.json` lines fire back-to-back, then MSB3491 fires immediately after.

## Fix

Pass `-p:BaseIntermediateOutputPath` and `-p:BaseOutputPath` to each `dotnet run` invocation, so each consumer's implicit build of the preprocessor lands in its own isolated directory under `<consumer>/obj/PreprocessOpenApi/`:

```xml
<Exec WorkingDirectory="$(ProjectDir)"
      Command="dotnet run --project &quot;$(PreprocessOpenApiProject)&quot;
               --configuration Release
               -p:BaseIntermediateOutputPath=&quot;$(PreprocessOpenApiObjDir)&quot;
               -p:BaseOutputPath=&quot;$(PreprocessOpenApiBinDir)&quot;
               -- &quot;...&quot; &quot;...&quot;" />
```

The two parallel builds no longer share any files, so the race cannot occur. No locking / serialization / `--disable-parallel` needed.

## Files changed

- `src/Aviationexam.PayPalSdk.Orders/Aviationexam.PayPalSdk.Orders.csproj`
- `src/Aviationexam.PayPalSdk.Payments/Aviationexam.PayPalSdk.Payments.csproj`

## Test plan

Verified locally with a full clean restore:

```
rm -rf src/Aviationexam.PayPalSdk.{Orders,Payments}/openapi.v2*.json
rm -rf src/Aviationexam.PayPalSdk.{Orders,Payments}/PayPal*ClientV2
rm -rf src/Aviationexam.PreprocessOpenApi/{obj,bin}
dotnet restore --nologo
```

Both `Preprocess openapi.v2.original.json to the openapi.v2.json` runs complete in parallel, both Kiota generations succeed, all 5 projects restore cleanly.

Each consumer now has its own isolated `obj/PreprocessOpenApi/` (with `Release/` + `bin/`) - no shared files between the two parallel builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)